### PR TITLE
Travis CI config update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 language: node_js
 node_js:
   - "12"
@@ -6,6 +7,6 @@ cache: yarn
 deploy:
   provider: script
   script: serverless deploy
-  skip_cleanup: true
+  cleanup: true
   on:
     branch: master


### PR DESCRIPTION
- fix a warning
- explicit `os` version
- `dist` still implicitly defaults to the stable `ubuntu` release